### PR TITLE
fix: DDP rank desync in TokenBudgetBatchSampler — add set_epoch(), drop_last=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Fixed
 
-- **DDP rank desync in TokenBudgetBatchSampler** (`bucket_sampler.py`, `datamodule.py`, `trainable_architecture.py`)
+- **Latent correctness issue in TokenBudgetBatchSampler** (`bucket_sampler.py`, `datamodule.py`, `trainable_architecture.py`)
 
-  When training across multiple ranks, `scatter_into_chunks` produces unequal dataset sizes per rank. Each rank's `TokenBudgetBatchSampler` uses the same initial seed but operates on a different number of sequences, causing the generator state to diverge after each epoch. Over long training runs, rank batch counts differ, leading to DDP rank desync and AllReduce hangs.
+  When training across multiple ranks, `scatter_into_chunks` produces unequal dataset sizes per rank. Each rank's `TokenBudgetBatchSampler` uses the same initial seed but operates on a different number of sequences, causing the generator state to diverge after each epoch. Over long training runs, rank batch counts can differ.
+
+  Note: the training loop already mitigates batch count desync via `synchronize_int_min`. This fix does not address the AllReduce hang reported in the forum thread — that hang reproduces on a minimal script with no custom sampling and is a separate upstream NCCL/PyTorch bug.
 
   Three changes:
   - `TokenBudgetBatchSampler.set_epoch(epoch)`: reseeds the generator to `base_seed + epoch` before each epoch, ensuring identical generator state across all ranks at epoch start.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## [Unreleased] — fix/distributed-sampler-rank-desync
+
+### Fixed
+
+- **DDP rank desync in TokenBudgetBatchSampler** (`bucket_sampler.py`, `datamodule.py`, `trainable_architecture.py`)
+
+  When training across multiple ranks, `scatter_into_chunks` produces unequal dataset sizes per rank. Each rank's `TokenBudgetBatchSampler` uses the same initial seed but operates on a different number of sequences, causing the generator state to diverge after each epoch. Over long training runs, rank batch counts differ, leading to DDP rank desync and AllReduce hangs.
+
+  Three changes:
+  - `TokenBudgetBatchSampler.set_epoch(epoch)`: reseeds the generator to `base_seed + epoch` before each epoch, ensuring identical generator state across all ranks at epoch start.
+  - `drop_last=True` on the distributed sampler: drops the final incomplete batch, preventing unequal batch counts from unequal chunk sizes.
+  - `trainable_architecture.py`: calls `set_epoch(epoch)` on the sampler before each epoch's training loop.

--- a/transformer_architectures/architectures/vanilla/datamodule.py
+++ b/transformer_architectures/architectures/vanilla/datamodule.py
@@ -74,6 +74,7 @@ class TransformerDataModule(distributed.DataModule):
                 token_budget=self.token_budget,
                 sort_window=self.sort_window,
                 generator=self.generator,
+                drop_last=True,  # required for DDP: prevents rank desync from unequal batch counts
             )
 
     def train_dataloader(self) -> torchd.DataLoader[dict[str, np.ndarray]]:

--- a/transformer_architectures/samplers/bucket_sampler.py
+++ b/transformer_architectures/samplers/bucket_sampler.py
@@ -37,12 +37,24 @@ class TokenBudgetBatchSampler(torchd.Sampler[list[int]]):
         self.sort_window = sort_window
         self.generator = generator
         self.drop_last = drop_last
+        self._base_seed = int(generator.initial_seed()) if generator is not None else 42
         n = len(dataset)  # type: ignore[arg-type]
         self._lengths = [len(dataset[i][length_key]) for i in range(n)]
         # Pre-build once with global sort for a stable __len__ approximation.
         self._static_batches = self._pack(
             sorted(range(n), key=lambda i: self._lengths[i])
         )
+
+    def set_epoch(self, epoch: int) -> None:
+        """Reseed the generator for the given epoch.
+
+        Must be called on all ranks with the same epoch value before iterating
+        the dataloader in distributed training. Ensures generator state is
+        identical across ranks at the start of each epoch, preventing batch
+        count drift that causes DDP rank desync.
+        """
+        if self.generator is not None:
+            self.generator.manual_seed(self._base_seed + epoch)
 
     def _pack(self, indices: list[int]) -> list[list[int]]:
         """Pack a length-sorted index list into token-budget batches."""

--- a/transformer_architectures/training/distributed/trainable_architecture.py
+++ b/transformer_architectures/training/distributed/trainable_architecture.py
@@ -201,6 +201,8 @@ class TrainableArchitecture(Protocol, Generic[_TC]):
         global_step = 0
         best_eval = 0.0 if self.train_config.comparator == ">" else 1e9
         for epoch in range(self.train_config.epochs):
+            if hasattr(data_module, 'train_batch_sampler') and data_module.train_batch_sampler is not None:
+                data_module.train_batch_sampler.set_epoch(epoch)
             global_step = self.train_epoch(
                 model,  # type: ignore
                 data_module,


### PR DESCRIPTION
Diagnosed from the NCCL timeout logs in: https://forums.developer.nvidia.com/t/collective-operations-timeout-on-dual-spark-during-distributed-training/366147

**Latent correctness issue in TokenBudgetBatchSampler**

`scatter_into_chunks` produces unequal dataset sizes per rank. Each rank builds its own `TokenBudgetBatchSampler` on its local chunk using the same initial seed, but because the chunk sizes differ, the generator state diverges after each epoch. Over long training runs this causes rank batch counts to differ.

Note: the training loop already mitigates batch count desync via `synchronize_int_min`, so this fix does not address the AllReduce hang reported in the forum thread. That hang reproduces on a minimal script with no custom sampling and is a separate upstream NCCL/PyTorch bug.

**Changes**

`bucket_sampler.py`
- Store `_base_seed` from the generator at init
- Add `set_epoch(epoch)` — reseeds the generator to `base_seed + epoch` before each epoch, ensuring identical generator state across all ranks at epoch start

`datamodule.py`
- Add `drop_last=True` to the sampler constructor — drops the final incomplete batch, preventing unequal batch counts from unequal scatter chunk sizes

`trainable_architecture.py`
- Call `set_epoch(epoch)` on the sampler before each epoch's training loop
